### PR TITLE
Fixed error in garnish_plot

### DIFF
--- a/R/antigen.garnish_io.R
+++ b/R/antigen.garnish_io.R
@@ -508,7 +508,10 @@ garnish_plot <- function(input){
   lapply(input %>% seq_along, function(i){
 
     dt <- input[[i]]
-    dt <- data.table::copy(dt)
+    dt <- data.table::copy(dt) %>%
+      unique(by = c("pep_type",
+                    "MHC",
+                    "nmer"))
 
       if (!(c("nmer",
               "MHC",


### PR DESCRIPTION
Failed to only count unique nmers, this led to a discrepancy and overestimation in garnish_plot for fusion peptides that did not match garnish_summary.